### PR TITLE
fix: remove /docs/ prefix from llms.txt documentation map URLs

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -245,24 +245,26 @@ Response time: 48-hour acknowledgment, 5 business days initial assessment.
 
 ## Documentation Map
 
-- About Silhouette: /docs/about-silhouette
-- Quickstart: /docs/quickstart
-- Onboarding - Start Trading: /docs/onboarding/start-trading
-- Onboarding - Withdraw: /docs/onboarding/withdraw
-- Shielded Trading: /docs/trading/shielded-trading
-- Naked Trading: /docs/trading/naked-trading
-- Order Types: /docs/trading/order-types
-- Architecture Overview: /docs/architecture/overview
-- TEE: /docs/architecture/tee
-- Hyperliquid: /docs/architecture/hyperliquid
-- Fees: /docs/fees
-- Referrals: /docs/referrals
-- FAQ: /docs/faq
-- Glossary: /docs/glossary
-- API Overview: /docs/api
-- API Quick Start: /docs/api/quick-start
-- API Authentication: /docs/api/authentication
-- API Reference: /docs/api/reference
-- API Troubleshooting: /docs/api/troubleshooting
-- OpenAPI Spec: /docs/api/openapi
-- Python SDK: /docs/sdk
+- About Silhouette: /about-silhouette
+- Quickstart: /quickstart
+- How Silhouette Works: /how-silhouette-works
+- Onboarding - Start Trading: /onboarding/start-trading
+- Onboarding - Withdraw: /onboarding/withdraw
+- Shielded Trading: /trading/shielded-trading
+- Naked Trading: /trading/naked-trading
+- Order Types: /trading/order-types
+- Order Lifecycle: /trading/order-lifecycle
+- Architecture Overview: /architecture/overview
+- TEE: /architecture/tee
+- Hyperliquid: /architecture/hyperliquid
+- Fees: /trading/fees
+- Referrals: /referrals
+- FAQ: /faq
+- Glossary: /glossary
+- API Overview: /api
+- API Quick Start: /api/quick-start
+- API Authentication: /api/authentication
+- API Reference: /api/reference
+- API Troubleshooting: /api/troubleshooting
+- OpenAPI Spec: /api/openapi
+- Python SDK: /sdk


### PR DESCRIPTION
## Summary

- Removed incorrect `/docs/` prefix from all 21 URLs in the `llms.txt` documentation map (Docusaurus `routeBasePath` is `/`, so docs are served at the site root)
- Fixed `/fees` path to `/trading/fees` (matching the page's frontmatter slug)
- Added 2 missing pages: `/how-silhouette-works` and `/trading/order-lifecycle`

## Context

The `llms.txt` file is consumed by LLMs (ChatGPT, Claude, Perplexity, etc.) to understand the site. Since it's a static file, Docusaurus's `onBrokenLinks: 'throw'` doesn't catch these - every link in the documentation map was returning a 404.

## Test plan

- [ ] Verify each URL in the documentation map resolves correctly on the Vercel preview
- [ ] Confirm no other files are affected (markdown links were already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)