### PR TITLE
Bring API reference docs up to date

### DIFF
--- a/docs/10-api/03-reference.md
+++ b/docs/10-api/03-reference.md
@@ -21,7 +21,11 @@ The Silhouette API and SDK are in beta. We are actively adding new operations.
 
 This section provides detailed documentation for each available API operation. All operations use the same endpoint with different `operation` values in the request body. For an overview of how the API works, see the [API Overview](/api).
 
-## login
+## Public Operations
+
+Public operations do not require a bearer token. Use these operations to authenticate, check public service metadata, and discover supported tokens and markets.
+
+### login
 
 Authenticate with the Silhouette API using [Sign-In With Ethereum (SIWE)](https://docs.login.xyz/) to obtain a [bearer token](https://datatracker.ietf.org/doc/html/rfc6750). This operation does not require an existing bearer token - it's the first step in using the API.
 
@@ -121,9 +125,197 @@ curl https://api.silhouette.exchange/v0 \
 - You can use the [login assistant](https://login.silhouette.exchange/) for a simplified authentication flow
 - **API wallet login**: If you provide a `primaryAddress`, the SIWE message must be signed by an API wallet authorized for that primary address. The returned JWT will contain the `primaryAddress`, so all downstream operations work the same as a direct login. See [Authentication](/api/authentication#api-wallet-login) for details.
 
-**Related operations**: This operation is prerequisite for all other operations except `login` itself.
+**Related operations**: This operation is prerequisite for private user-scoped operations such as `getBalances`, `createOrder`, and withdrawals.
 
-## getBalances
+### getTokens
+
+Retrieve metadata for all tokens currently supported by the API. This is a public discovery operation; use it instead of hardcoding token metadata in your integration.
+
+**Endpoint**: `POST https://api.silhouette.exchange/v0`
+
+**Authentication**: Not required
+
+**Request parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| operation | string | Yes | Must be `"getTokens"` |
+
+**Example request**:
+
+```bash
+curl https://api.silhouette.exchange/v0 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "getTokens"
+  }'
+```
+
+**Success response**:
+
+```json
+{
+  "operation": "getTokens",
+  "tokens": [
+    {
+      "name": "USDC",
+      "fullName": null,
+      "index": 0,
+      "tokenId": "0x6d1e7cde53ba9467b783cb7c530ce054",
+      "szDecimals": 8,
+      "weiDecimals": 8,
+      "isCanonical": true,
+      "evmContract": {
+        "address": "0x6b9e773128f453f5c2c60935ee2de2cbc5390a24",
+        "evm_extra_wei_decimals": -2
+      }
+    },
+    {
+      "name": "HYPE",
+      "fullName": "Hyperliquid",
+      "index": 150,
+      "tokenId": "0x0d01dc56dcaaca66ad901c959b4011ec",
+      "szDecimals": 2,
+      "weiDecimals": 8,
+      "isCanonical": false,
+      "evmContract": null
+    }
+  ],
+  "responseMetadata": {
+    "timestamp": 1704067200000,
+    "requestId": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+**Response fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tokens | array | Supported token metadata records |
+| tokens[].name | string | Token symbol used in API requests, balances, orders, and withdrawals |
+| tokens[].fullName | string \| null | Full token name, when available |
+| tokens[].index | number | Hyperliquid spot token index |
+| tokens[].tokenId | string | Hyperliquid token ID as a hex string |
+| tokens[].szDecimals | number | Decimal precision for order sizes |
+| tokens[].weiDecimals | number | Decimal precision for the token's smallest unit |
+| tokens[].isCanonical | boolean | Whether the token is canonical on Hyperliquid |
+| tokens[].evmContract | object \| null | EVM contract metadata, when available |
+| tokens[].evmContract.address | string | EVM contract address |
+| tokens[].evmContract.evm_extra_wei_decimals | number | Additional EVM decimal adjustment for the contract |
+
+**Error responses**:
+
+```json
+{
+  "operation": "getTokens",
+  "error": "Internal server error",
+  "code": "INTERNAL_ERROR",
+  "responseMetadata": {
+    "timestamp": 1704067200000
+  }
+}
+```
+
+**Notes**:
+
+- This operation is public; do not include an `Authorization` header unless your client adds one globally
+- The supported token set can vary by environment and may change over time
+- Use `name` as the token symbol for `baseToken`, `quoteToken`, and `tokenSymbol` fields
+- Use `getMarkets` to discover which token pairs are currently enabled for trading
+
+**Related operations**: Use `getMarkets` to discover supported trading pairs, `getBalances` to view your balances, and `createOrder` to trade supported tokens.
+
+### getMarkets
+
+Retrieve metadata for all trading pairs currently supported by the API. This is a public discovery operation; use it to validate `baseToken` and `quoteToken` values before creating orders.
+
+**Endpoint**: `POST https://api.silhouette.exchange/v0`
+
+**Authentication**: Not required
+
+**Request parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| operation | string | Yes | Must be `"getMarkets"` |
+
+**Example request**:
+
+```bash
+curl https://api.silhouette.exchange/v0 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "getMarkets"
+  }'
+```
+
+**Success response**:
+
+```json
+{
+  "operation": "getMarkets",
+  "markets": [
+    {
+      "name": "HYPE/USDC",
+      "baseToken": "HYPE",
+      "quoteToken": "USDC",
+      "baseTokenIndex": 150,
+      "quoteTokenIndex": 0
+    },
+    {
+      "name": "HYPE/USDH",
+      "baseToken": "HYPE",
+      "quoteToken": "USDH",
+      "baseTokenIndex": 150,
+      "quoteTokenIndex": 360
+    }
+  ],
+  "responseMetadata": {
+    "timestamp": 1704067200000,
+    "requestId": "650e8400-e29b-41d4-a716-446655440001"
+  }
+}
+```
+
+**Response fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| markets | array | Supported trading-pair metadata records |
+| markets[].name | string | Market pair name in `BASE/QUOTE` format |
+| markets[].baseToken | string | Base token symbol for the pair |
+| markets[].quoteToken | string | Quote token symbol for the pair |
+| markets[].baseTokenIndex | number | Hyperliquid spot token index for the base token |
+| markets[].quoteTokenIndex | number | Hyperliquid spot token index for the quote token |
+
+**Error responses**:
+
+```json
+{
+  "operation": "getMarkets",
+  "error": "Internal server error",
+  "code": "INTERNAL_ERROR",
+  "responseMetadata": {
+    "timestamp": 1704067200000
+  }
+}
+```
+
+**Notes**:
+
+- This operation is public; do not include an `Authorization` header unless your client adds one globally
+- The supported market set can vary by environment and may change over time
+- The `name` field is informational; pass `baseToken` and `quoteToken` separately when calling `createOrder`
+- Markets with unavailable token metadata are excluded from the response
+
+**Related operations**: Use `getTokens` for token-level metadata and `createOrder` to place an order on a supported market.
+
+## Authenticated Operations
+
+Authenticated operations require a bearer token in the `Authorization` header and return or modify state scoped to the authenticated user.
+
+### getBalances
 
 Retrieve your account balance information for all tokens. This shows your available balance (funds you can trade or withdraw), locked balance (funds tied up in open orders), and total balance.
 
@@ -218,7 +410,7 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `createOrder` to trade with your available balance, or `initiateWithdrawal` to withdraw available funds.
 
-## createOrder
+### createOrder
 
 Create a new spot order to buy or sell tokens. All orders require an explicit `price` and are submitted to Hyperliquid as IOC (Immediate or Cancel) orders.
 
@@ -338,7 +530,7 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `listDelegatedOrders` to view your orders, and `getBalances` to check available funds.
 
-## listDelegatedOrders
+### listDelegatedOrders
 
 Retrieve a paginated list of delegated orders for the authenticated user, optionally filtered by status, order type, or creation time. This is the primary way to enumerate orders placed on your behalf via `createOrder`.
 
@@ -430,7 +622,7 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `getDelegatedOrder` or `batchGetDelegatedOrders` to fetch full detail, and `createOrder` to place new orders.
 
-## getDelegatedOrder
+### getDelegatedOrder
 
 Retrieve full details for a single delegated order by its order ID.
 
@@ -529,7 +721,7 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `listDelegatedOrders` to enumerate orders, and `batchGetDelegatedOrders` to fetch multiple orders in one call.
 
-## batchGetDelegatedOrders
+### batchGetDelegatedOrders
 
 Retrieve full details for up to 100 delegated orders in a single request.
 
@@ -606,13 +798,13 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `listDelegatedOrders` to discover order IDs, and `getDelegatedOrder` to fetch a single order.
 
-## getUserOrders
+### getUserOrders
 
 :::danger Decommissioned
 `getUserOrders` has been fully decommissioned. Use the delegated-order operations instead: `listDelegatedOrders` to enumerate and paginate orders, `getDelegatedOrder` for a single order, or `batchGetDelegatedOrders` to fetch multiple orders in one call.
 :::
 
-## initiateWithdrawal
+### initiateWithdrawal
 
 Request a withdrawal of funds from your Silhouette account back to your HyperCore address. Withdrawals are processed asynchronously, and you'll receive a withdrawal ID to track the status.
 
@@ -713,7 +905,7 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `getWithdrawalStatus` to check withdrawal progress, `getUserWithdrawals` to view all your withdrawals, and `getBalances` to verify available funds.
 
-## getWithdrawalStatus
+### getWithdrawalStatus
 
 Check the status of a specific withdrawal using its withdrawal ID. This shows whether the withdrawal is still pending, has completed successfully, or has failed.
 
@@ -859,7 +1051,7 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `initiateWithdrawal` to request a withdrawal, and `getUserWithdrawals` to view all your withdrawals.
 
-## getUserWithdrawals
+### getUserWithdrawals
 
 Retrieve a list of all your withdrawal requests, including their current status. This provides a complete history of your withdrawals.
 

--- a/docs/10-api/03-reference.md
+++ b/docs/10-api/03-reference.md
@@ -410,6 +410,81 @@ curl https://api.silhouette.exchange/v0 \
 
 **Related operations**: Use `createOrder` to trade with your available balance, or `initiateWithdrawal` to withdraw available funds.
 
+### getFees
+
+Retrieve the spot maker and taker fee rates for the authenticated user.
+
+**Endpoint**: `POST https://api.silhouette.exchange/v0`
+
+**Authentication**: Required
+
+**Request parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| operation | string | Yes | Must be `"getFees"` |
+
+**Example request**:
+
+```bash
+curl https://api.silhouette.exchange/v0 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  -d '{
+    "operation": "getFees"
+  }'
+```
+
+**Success response**:
+
+```json
+{
+  "operation": "getFees",
+  "fees": {
+    "spot": {
+      "takerRate": "0.000700",
+      "makerRate": "0.000200",
+      "takerRatePpm": "700",
+      "makerRatePpm": "200"
+    }
+  },
+  "responseMetadata": {
+    "timestamp": 1704067200000,
+    "requestId": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+**Response fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| fees.spot.takerRate | string | Spot taker fee as a decimal fraction. For example, `"0.000700"` is 0.07%. |
+| fees.spot.makerRate | string | Spot maker fee as a decimal fraction. For example, `"0.000200"` is 0.02%. |
+| fees.spot.takerRatePpm | string | Spot taker fee in parts per million |
+| fees.spot.makerRatePpm | string | Spot maker fee in parts per million |
+
+**Error responses**:
+
+```json
+{
+  "operation": "getFees",
+  "error": "Unauthorized",
+  "code": "UNAUTHORIZED",
+  "responseMetadata": {
+    "timestamp": 1704067200000
+  }
+}
+```
+
+**Notes**:
+
+- Fee rates are scoped to the authenticated user
+- Decimal rate fields are strings for exact transport and display
+- PPM fields are integer strings; for example, `"700"` means 700 parts per million, or 0.07%
+
+**Related operations**: Use `createOrder` to place orders that use these fee rates.
+
 ### createOrder
 
 Create a new spot order to buy or sell tokens. All orders require an explicit `price` and are submitted to Hyperliquid as IOC (Immediate or Cancel) orders.
@@ -529,6 +604,97 @@ curl https://api.silhouette.exchange/v0 \
 - Save the returned `orderId` to track the order or correlate it with delegated-order records later.
 
 **Related operations**: Use `listDelegatedOrders` to view your orders, and `getBalances` to check available funds.
+
+### cancelOrder
+
+Cancel an open order for the authenticated user. Currently only GTC limit orders support cancellation.
+
+**Endpoint**: `POST https://api.silhouette.exchange/v0`
+
+**Authentication**: Required
+
+**Request parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| operation | string | Yes | Must be `"cancelOrder"` |
+| orderId | string | Yes | The `orderId` returned by `createOrder` for the cancellable limit order. Must be a `0x`-prefixed 32-character hex string. |
+
+**Example request**:
+
+```bash
+curl https://api.silhouette.exchange/v0 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  -d '{
+    "operation": "cancelOrder",
+    "orderId": "0x1234567890abcdef1234567890abcdef"
+  }'
+```
+
+**Success response**:
+
+```json
+{
+  "operation": "cancelOrder",
+  "message": "Order canceled successfully.",
+  "orderId": "0x1234567890abcdef1234567890abcdef",
+  "responseMetadata": {
+    "timestamp": 1704067200000,
+    "requestId": "650e8400-e29b-41d4-a716-446655440001"
+  }
+}
+```
+
+**Response fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| message | string | Cancellation result message |
+| orderId | string | Cancelled order ID |
+
+**Error responses**:
+
+```json
+{
+  "operation": "cancelOrder",
+  "error": "Missing required field: orderId.",
+  "code": "VALIDATION_ERROR",
+  "responseMetadata": {
+    "timestamp": 1704067200000
+  }
+}
+```
+
+```json
+{
+  "operation": "cancelOrder",
+  "error": "Invalid orderId format. Expected a 0x-prefixed 32-character hex string.",
+  "code": "VALIDATION_ERROR",
+  "responseMetadata": {
+    "timestamp": 1704067200000
+  }
+}
+```
+
+```json
+{
+  "operation": "cancelOrder",
+  "error": "Failed to cancel order.",
+  "code": "ORDER_ERROR",
+  "responseMetadata": {
+    "timestamp": 1704067200000
+  }
+}
+```
+
+**Notes**:
+
+- `cancelOrder` is for cancellable GTC limit orders
+- Use the `orderId` returned by `createOrder`. Do not pass a delegated-order ID such as `dord_...`
+- IOC orders normally fill or cancel immediately and are not cancellable through this operation
+
+**Related operations**: Use `createOrder` to place orders and delegated-order operations to inspect delegated-order records.
 
 ### listDelegatedOrders
 

--- a/docs/10-api/03-reference.md
+++ b/docs/10-api/03-reference.md
@@ -660,17 +660,17 @@ curl https://api.silhouette.exchange/v0 \
     "orderType": "limit",
     "baseToken": "HYPE",
     "quoteToken": "USDC",
-    "amount": "1000000",
-    "amountFloat": "0.01",
-    "price": "40000000",
+    "amount": "100000000",
+    "amountFloat": "1",
+    "price": "4000000000",
     "priceFloat": "40",
     "status": "filled",
     "expiry": 1704153600,
     "createdAt": 1704067200000,
     "updatedAt": 1704070800000,
-    "filledAmount": "1000000",
-    "filledPrice": "39500000",
+    "filledAmount": "100000000",
     "remainingAmount": "0",
+    "averageFillPrice": "4000000000",
     "clearingVenue": "hyperliquid"
   },
   "responseMetadata": {
@@ -688,17 +688,18 @@ curl https://api.silhouette.exchange/v0 \
 | order.orderType | string | Order type: `"limit"` or `"market"` |
 | order.baseToken | string | Base token symbol |
 | order.quoteToken | string | Quote token symbol |
-| order.amount | string | Order amount in the token's smallest unit |
-| order.amountFloat | string | Order amount as a human-readable decimal |
-| order.price | string | Order price in the smallest unit, for limit orders |
-| order.priceFloat | string | Order price as a human-readable decimal |
+| order.amount | string | Base-token order amount as an exact integer string, scaled by `10^baseToken.weiDecimals` |
+| order.amountFloat | string | Human-readable base-token order amount convenience string |
+| order.price | string | Limit price as an exact integer string, scaled by `10^8` |
+| order.priceFloat | string | Human-readable limit price convenience string |
 | order.status | string | Current order status |
 | order.expiry | number | Order expiry as a Unix timestamp (seconds) |
 | order.createdAt | number | Unix timestamp (milliseconds) when the order was created |
 | order.updatedAt | number | Unix timestamp (milliseconds) when the order was last updated |
-| order.filledAmount | string | Amount filled, for `filled` or `partially_filled` orders |
-| order.filledPrice | string | Execution price, for `filled` or `partially_filled` orders |
-| order.remainingAmount | string | Unfilled amount in the token's smallest unit |
+| order.filledAmount | string | Filled base-token amount as an exact integer string, scaled by `10^baseToken.weiDecimals` |
+| order.remainingAmount | string | Remaining unfilled base-token amount as an exact integer string, scaled by `10^baseToken.weiDecimals` |
+| order.averageFillPrice | string | Average execution price as an exact integer string, scaled by `10^8`. Present for `filled` or `partially_filled` orders. |
+| order.filledPrice | string | Deprecated legacy execution-price field. Use `averageFillPrice` instead. |
 | order.clearingVenue | string | Venue where the order is executed (currently always `"hyperliquid"`) |
 
 **Error responses**:
@@ -718,6 +719,12 @@ curl https://api.silhouette.exchange/v0 \
 
 - You can only retrieve delegated orders that belong to the authenticated user. Looking up another user's order returns `NOT_FOUND`
 - To retrieve several orders in a single request, use `batchGetDelegatedOrders`
+- Delegated-order amounts and prices are returned as exact integer strings to preserve precision. For accounting-sensitive logic, parse these fields as arbitrary-precision integers, such as JavaScript `BigInt`, and apply the documented scale when formatting values for display.
+- `amount`, `filledAmount`, and `remainingAmount` are base-token amounts scaled by `10^baseToken.weiDecimals`. Get `weiDecimals` from the public unauthenticated `getTokens` operation.
+- `price` and `averageFillPrice` are price fields scaled by `10^8`. To convert to a decimal price, divide by `100,000,000`.
+- `amountFloat` and `priceFloat` are convenience strings for display. Use the exact integer string fields for accounting-sensitive logic.
+- Example: If `baseToken = HYPE` and `HYPE.weiDecimals = 8`, then `filledAmount = "100000000"` means 1.0 HYPE, `remainingAmount = "50000000"` means 0.5 HYPE, and `averageFillPrice = "4000000000"` means 40.0 quote tokens per 1 base token.
+- `filledPrice` is deprecated in delegated-order detail responses. Use `averageFillPrice` instead.
 
 **Related operations**: Use `listDelegatedOrders` to enumerate orders, and `batchGetDelegatedOrders` to fetch multiple orders in one call.
 
@@ -763,15 +770,17 @@ curl https://api.silhouette.exchange/v0 \
       "orderType": "limit",
       "baseToken": "HYPE",
       "quoteToken": "USDC",
-      "amount": "1000000",
-      "amountFloat": "0.01",
-      "price": "40000000",
+      "amount": "100000000",
+      "amountFloat": "1",
+      "price": "4000000000",
       "priceFloat": "40",
-      "status": "open",
+      "status": "partially_filled",
       "expiry": 1704153600,
       "createdAt": 1704067200000,
       "updatedAt": 1704067200000,
-      "remainingAmount": "1000000",
+      "filledAmount": "50000000",
+      "remainingAmount": "50000000",
+      "averageFillPrice": "4000000000",
       "clearingVenue": "hyperliquid"
     }
   ],
@@ -795,6 +804,9 @@ curl https://api.silhouette.exchange/v0 \
 
 - Request up to 100 `orderIds` per call
 - Missing or foreign orders are reported through `notFound` rather than an error, so partial results are always returned when at least one ID resolves
+- Delegated-order amount and price fields in `orders` use the same exact integer string contract as `getDelegatedOrder`
+- `amountFloat` and `priceFloat` are convenience strings for display. Use the exact integer string fields for accounting-sensitive logic.
+- `filledPrice` is deprecated in delegated-order detail responses. Use `averageFillPrice` instead.
 
 **Related operations**: Use `listDelegatedOrders` to discover order IDs, and `getDelegatedOrder` to fetch a single order.
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -113,23 +113,17 @@ The easiest way to authenticate is via the login assistant at https://login.silh
 
 ### Available Operations
 
-**Authentication:**
+**Public operations:**
 - `login` — Authenticate via SIWE to get a JWT bearer token. No auth required.
-
-**Balances:**
-- `getBalances` — Get available, locked, and total balances for all tokens. Auth required.
-
-**Discovery & Health:**
 - `getTokens` — Get metadata for supported tokens.
 - `getMarkets` — Get metadata for supported markets.
 - `getHealth`, `getHealthFeatures`, `getHealthInfo`, `getHealthReady` — Health and feature discovery endpoints.
 
-**Orders:**
+**Authenticated operations:**
+- `getBalances` — Get available, locked, and total balances for all tokens. Auth required.
 - `createOrder` — Place a buy or sell shielded spot order. The current live flow requires `price` and submits the order as a delegated IoC. Auth required.
-- `getUserOrders` — List orders, optionally filtered by `status` (pending, open, filled, partially_filled, cancelled, expired, failed). Auth required.
 - `listDelegatedOrders`, `getDelegatedOrder`, `batchGetDelegatedOrders` — Query delegated-order records. Auth required.
-
-**Withdrawals:**
+- `getUserOrders` — Decommissioned. Use the delegated-order operations instead.
 - `initiateWithdrawal` — Request withdrawal of an enabled token symbol for `amount`. Only one pending withdrawal at a time. Auth required.
 - `getWithdrawalStatus` — Check status of a withdrawal by `withdrawalId`. States: pending, completed, failed. Auth required.
 - `getUserWithdrawals` — List all your withdrawals. Auth required.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -176,6 +176,8 @@ Amounts in API responses come in two formats:
 
 When sending amounts in requests (createOrder, initiateWithdrawal), use human-readable decimal strings (e.g., `"100"` or `"100.5"`). Values are automatically scaled.
 
+Delegated-order detail responses (`getDelegatedOrder` and `batchGetDelegatedOrders`) return accounting-sensitive numeric fields as exact integer strings, not JavaScript numbers. Parse these fields as arbitrary-precision integers, such as JavaScript `BigInt`, and apply the documented scale when formatting values for display. `amount`, `filledAmount`, and `remainingAmount` are base-token amounts scaled by `10^baseToken.weiDecimals`; get `weiDecimals` from the public `getTokens` operation. `price` and `averageFillPrice` are price fields scaled by `10^8`; divide by `100,000,000` to convert to a decimal price. `amountFloat` and `priceFloat` are convenience strings for display. `filledPrice` is deprecated; use `averageFillPrice`.
+
 ### Supported Tokens
 
 Use `getTokens` and `getMarkets` to discover the live supported set. Current app-facing environments include USDC, USDH, and HYPE, with additional assets enabled in some deployments.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -121,7 +121,9 @@ The easiest way to authenticate is via the login assistant at https://login.silh
 
 **Authenticated operations:**
 - `getBalances` — Get available, locked, and total balances for all tokens. Auth required.
+- `getFees` — Get authenticated-user spot maker and taker fee rates. Auth required.
 - `createOrder` — Place a buy or sell shielded spot order. The current live flow requires `price` and submits the order as a delegated IoC. Auth required.
+- `cancelOrder` — Cancel a cancellable GTC limit order using the `orderId` returned by `createOrder`. Auth required.
 - `listDelegatedOrders`, `getDelegatedOrder`, `batchGetDelegatedOrders` — Query delegated-order records. Auth required.
 - `getUserOrders` — Decommissioned. Use the delegated-order operations instead.
 - `initiateWithdrawal` — Request withdrawal of an enabled token symbol for `amount`. Only one pending withdrawal at a time. Auth required.


### PR DESCRIPTION
- [Add getTokens and getMarkets operations to API reference](https://github.com/silhouette-exchange/public-docs/commit/1c1dd6d57fe0d35a6bd1487988d211befa5a2baf)
- [Document delegated order numeric fields](https://github.com/silhouette-exchange/public-docs/commit/ed14faca3c3f45fcfefbfaa97966e9f2efd97322)
- [Document fees and order cancellation APIs](https://github.com/silhouette-exchange/public-docs/commit/7c702169670040a7b933b0b4fee016b950ad108c)