### PR TITLE
chore: gitignore .pnpm-store and .vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 /node_modules
+.pnpm-store/
 
 # Production
 /build
@@ -7,6 +8,9 @@
 # Generated files
 .docusaurus
 .cache-loader
+
+# Vercel CLI link
+.vercel/
 
 # Misc
 .DS_Store


### PR DESCRIPTION
## Summary

Adds two local-only directories to \`.gitignore\`:

- **\`.pnpm-store/\`** — local pnpm package cache, created on \`pnpm install\` / \`pnpm build\`
- **\`.vercel/\`** — Vercel CLI link metadata (\`project.json\` + \`README.txt\`), created when running \`vercel\` locally

Neither contains secrets (Vercel auth tokens live in \`~/.local/share/com.vercel.cli/\`, not the project folder), but they're machine-local artefacts that shouldn't be versioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)