### PR TITLE
Hide unfinished Guides section from search and public surfaces

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -195,17 +195,27 @@ const config: Config = {
         highlightSearchTermsOnTargetPage: true,
       },
     ],
-    [
-      '@docusaurus/plugin-content-docs',
-      {
-        id: 'guides',
-        path: 'guides',
-        routeBasePath: 'guides',
-        sidebarPath: require.resolve('./guidesSidebars.ts'),
-        showLastUpdateTime: false,
-        showLastUpdateAuthor: false,
-      },
-    ],
+    /*
+     * Guides plugin disabled until Phase 2 content ships.
+     * The placeholder pages were appearing in the search index even
+     * though navbar, sitemap, and llms.txt already excluded them.
+     * Disabling the plugin entirely stops the routes from being built,
+     * which removes them from every public surface in one shot.
+     * To re-enable: uncomment this block. The sidebar file
+     * (guidesSidebars.ts) and content under guides/ are kept on disk
+     * and ready to ship.
+     */
+    // [
+    //   '@docusaurus/plugin-content-docs',
+    //   {
+    //     id: 'guides',
+    //     path: 'guides',
+    //     routeBasePath: 'guides',
+    //     sidebarPath: require.resolve('./guidesSidebars.ts'),
+    //     showLastUpdateTime: false,
+    //     showLastUpdateAuthor: false,
+    //   },
+    // ],
     [
       '@signalwire/docusaurus-plugin-llms-txt',
       {


### PR DESCRIPTION
## Summary

Disables the `@docusaurus/plugin-content-docs` `guides` instance until Phase 2 guide content ships. Stops the placeholder pages from appearing in the local search index (the bug Wayne flagged: searching \"trade\" surfaced the Coming-in-Phase-2 stubs).

## Why a one-liner config change instead of a search-plugin filter

`@easyops-cn/docusaurus-search-local` indexes all docs plugin instances by default. The cleanest fix is to not build the routes at all, since they were already excluded from navbar, sitemap, and llms.txt anyway. Disabling the plugin removes them from every public surface (search, sitemap, llms.txt, direct URL) in one shot, and matches the existing \"hide until ready\" pattern (RFQ + HIP-4 disabled sidebar placeholders).

## What stays

- `guides/` folder content (6 placeholder pages with Phase 2 callouts)
- `guidesSidebars.ts`
- The `/guides/**` exclusions in sitemap config and llms.txt config (dead code while plugin is off, ready when it comes back)

## Re-enabling later

Uncomment the plugin block in `docusaurus.config.ts`. No other changes required.

## Verified via production build

- Zero `/guides/*` paths in `build/` output
- Zero guide matches in `build/search-index.json`
- No guide URLs in `build/llms.txt` or `build/llms-full.txt`
- Build succeeded cleanly: \`Generated static files in \"build\"\`

## Test plan

- [x] Vercel PR preview builds successfully
- [x] Search the preview for \"trade\" - no Guides results
- [x] Hit `/guides/`, `/guides/for-traders`, `/guides/for-developers`, `/guides/for-institutions` directly on the preview - all 404
- [x] Existing pages still work (homepage, /trading/fees, /api/, /blog)